### PR TITLE
Fixed TOC pointers for moccasin buy me a coffee workshops 1 & 2 to resolve #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Please refer to this for an in-depth explanation of the content:
       <li><a href="#test-types">Test types</a></li>
       <li><a href="#workshops">Workshops</a>
         <ul>
-          <li><a href="#workshop-1">Workshop 1</a></li>
-          <li><a href="#workshop-2">Workshop 2</a></li>
+          <li><a href="#mox-coffee-workshop-1">Workshop 1</a></li>
+          <li><a href="#mox-coffee-workshop-2">Workshop 2</a></li>
         </ul>
       </li>
     </ul>
@@ -761,7 +761,7 @@ There are many types of tests:
 
 Spend at most 25 minutes on all of these prompts without the aide of AI. If you're unable to solve them after 25 minutes, stop, take a break, and then work with an AI or the discussions to help you solve them. Good luck!
 
-#### Workshop 1
+<h4 id="mox-coffee-workshop-1">Workshop 1</h3>
 
 Write a test that:
 - Funds the contract with 10 different funders
@@ -770,7 +770,7 @@ Write a test that:
   - The ending balance of `buy_me_a_coffee` is 0
   - The ending balance of the owner is the addition of all the amounts the funders added
 
-#### Workshop 2
+<h4 id="mox-coffee-workshop-2">Workshop 2</h3>
 1. Write enough tests to get you over 95% code coverage for `buy_me_a_coffee.vy`
 2. Sign up for [Cyfrin Profiles!](https://profiles.cyfrin.io) (And then tweet at me!)
 3. Push your code up to GitHub


### PR DESCRIPTION
Related issue: #26 

Minor issue with the TOC links for the Mox "Buy Me a Coffee" workshop subjects. The links were not pointing to the correct IDs:

Workshop1 -> Section 2: Remix Buy Me A Coffee/Workshop
Workshop2 -> Section 3: AI Prompting, Asking Questions, and Researching/Workshop

Problem origin: the TOC generator does not handle well the duplicated IDs
```
+ #workshop-1 ID generated from TOC extension under mox-coffee #workshops section
- #workshop-1 already taken by Section 2: Remix Buy Me A Coffee/Workshop

+ #workshop-2 ID generated from TOC extension under mox-coffee #workshops section
- #workshop-2 already taken by Section 3: AI Prompting, Asking Questions, and Researching/Workshop
```

To address the issue, I have replaced `####` titles with raw `<h4></h4>` HTML tags with custom IDs. Now the TOC pointers are updated to redirect to the right workshop sections for `mox-buy-me-a-coffee`